### PR TITLE
Avoid overwriting zle widgets and more flexible visual indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # zsh-vim-mode
 Sane bindings for zsh's vi mode so it behaves more vim like
 
+## Requirements
+
+* [zsh-hooks](http://github.com/willghatch/zsh-hooks) needs to be installed
+
+## Installation
+
+* This plugin can be installed with [zgen](http://github.com/tarjoilija/zgen) or [antigen](http://github.com/zsh-users/antigen) as described in the corresponding documentation.
+
 ## Install with oh-my-zsh
 * Download the script or clone this repository in [oh-my-zsh](http://github.com/robbyrussell/oh-my-zsh) plugins directory:
 
@@ -14,3 +22,11 @@ Sane bindings for zsh's vi mode so it behaves more vim like
 * Source `~/.zshrc`  to take changes into account:
 
         source ~/.zshrc
+
+## Configuration
+
+* **Highly recommended:** If you want a visual indicator of the current vi mode in your (left or right) prompt, add `$I_MODE` somewhere to your `PS1` or `RPROMPT` variable. It will be replaced with the current mode automatically.  
+E.g. use `PS1="$I_MODE $PS1"` or `RPROMPT=$I_MODE` (or both) somewhere in your `.zshrc`.
+
+* You can modify `$I_MODE` and `$N_MODE` if you don't like the defaults.
+

--- a/zsh-vim-mode.plugin.zsh
+++ b/zsh-vim-mode.plugin.zsh
@@ -121,16 +121,20 @@ if [[ -z $I_MODE ]]; then
   I_MODE="%{$fg[white]%}[I]%{$reset_color%}"
 fi
 
-function zle-line-init zle-keymap-select {
-  case $KEYMAP in
-    vicmd) RPROMPT=$N_MODE ;;
-    main|viins) RPROMPT=$I_MODE ;;
+function vim-mode-update-prompt {
+  case $ZSH_CUR_KEYMAP in
+    vicmd) CUR_MODE=$N_MODE ;;
+    main|viins) CUR_MODE=$I_MODE ;;
   esac
+  PS1=${PS1//($N_MODE|$I_MODE)/$CUR_MODE}
+  RPROMPT=${RPROMPT//($N_MODE|$I_MODE)/$CUR_MODE}
   zle reset-prompt
 }
 
-# Define right prompt, if it wasn't defined by a theme
-if [[ -z $RPS1 && -z $RPROMPT ]]; then
-    zle -N zle-line-init
-    zle -N zle-keymap-select
+if type -f hooks-add-hook 1>/dev/null 2>&1; then
+  hooks-add-hook zle_keymap_select_hook vim-mode-update-prompt
+  hooks-add-hook zle_line_init_hook vim-mode-update-prompt
+else
+  echo "zsh-hooks not loaded! Please load willghatch/zsh-hooks before zsh-vim-mode!"
 fi
+


### PR DESCRIPTION
Hi,

you seem to have the most active fork of this plugin, therefore I direct my PR to you.

My modifications:
- using hooks plugin, this allows multiple plugins to use the same zle widgets (e.g. zle-line-init) without interfering each other (downside: hooks plugin needs to be installed before this plugin [but it should be used by more plugins anyway])
- more flexible visual indicator anywhere in PS1 and/or RPROMPT (see README)
- adjusted README accordingly

Regards
Hagen
