### PR TITLE
Fix #3: Prevent global aliases from causing syntax errors

### DIFF
--- a/zsh-vim-mode.plugin.zsh
+++ b/zsh-vim-mode.plugin.zsh
@@ -508,9 +508,10 @@ case $TERM in
 esac
 
 # Restore shell option 'aliases' if it was previously enabled
+# Only `builtin`s should be used after (possibly) restoring aliases.
 if [[ $_shopt_aliases = 1 ]]; then
    set -o aliases
-   unset _shopt_aliases
+   builtin unset _shopt_aliases
 fi
 
 # vim:set ft=zsh sw=4 et fdm=marker:

--- a/zsh-vim-mode.plugin.zsh
+++ b/zsh-vim-mode.plugin.zsh
@@ -1,5 +1,5 @@
 # Global aliases can break things. Unset before using any non-builtins.
-[[ -o aliases ]] && local _shopt_aliases=1
+[[ -o aliases ]] && _shopt_aliases=1
 builtin set -o no_aliases
 
 bindkey -v

--- a/zsh-vim-mode.plugin.zsh
+++ b/zsh-vim-mode.plugin.zsh
@@ -1,3 +1,7 @@
+# Global aliases can break things. Unset before using any non-builtins.
+[[ -o aliases ]] && local _shopt_aliases=1
+builtin set -o no_aliases
+
 bindkey -v
 
 ${(%):-%x}_debug () { print -r "$(date) $@" >> /tmp/zsh-debug-vim-mode.log 2>&1 }
@@ -502,5 +506,11 @@ case $TERM in
         add-zle-hook-widget line-finish    vim-mode-cursor-finish-hook
         ;;
 esac
+
+# Restore shell option 'aliases' if it was previously enabled
+if [[ $_shopt_aliases = 1 ]]; then
+   set -o aliases
+   unset _shopt_aliases
+fi
 
 # vim:set ft=zsh sw=4 et fdm=marker:


### PR DESCRIPTION
Global aliases get expanded when `source`-ing a file.

Save current aliases shell option, then disable aliases before any non-builtins
are executed.

Restore aliases option at end if it was initially set.